### PR TITLE
v0.4.3: Add missing exports of v0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funixproductions/angular-core",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@angular/animations": "^19.1.7",
         "@angular/common": "^19.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Package used in all FunixProductions Angular projects",
   "scripts": {
     "ng": "ng",

--- a/projects/funixproductions-requests/package.json
+++ b/projects/funixproductions-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/funixproductions-requests",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Package used in all FunixProductions Angular projects",
   "peerDependencies": {
     "@angular/common": "^19.1.7",

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
@@ -1,6 +1,6 @@
 import {ApiDTO} from 'projects/funixproductions-requests/src/public-api';
 
-export class PacifistaPlayerDataDTO extends ApiDTO {
+export class PlayerDataDTO extends ApiDTO {
     public minecraftUuid: string;
 
     constructor(minecraftUuid: string) {

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerMoneyDTO.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerMoneyDTO.ts
@@ -1,6 +1,6 @@
-import {PacifistaPlayerDataDTO} from './PacifistaPlayerDataDTO';
+import {PlayerDataDTO} from './PlayerDataDTO';
 
-export class PacifistaPlayerMoneyDTO extends PacifistaPlayerDataDTO {
+export class PlayerMoneyDTO extends PlayerDataDTO {
     money: number;
     offlineMoney: number;
 

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/service/PlayerMoneyService.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/service/PlayerMoneyService.ts
@@ -1,10 +1,10 @@
 import {HttpClient} from "@angular/common/http";
 import {CrudHttpClient} from "projects/funixproductions-requests/src/public-api";
-import {PacifistaPlayerMoneyDTO} from "../dtos/PacifistaPlayerMoneyDTO";
+import {PlayerMoneyDTO} from "../dtos/PlayerMoneyDTO";
 import {environment} from "projects/funixproductions-requests/src/environments/environment";
 import {environmentDev} from "projects/funixproductions-requests/src/environments/environment-dev";
 
-export class PacifistaPlayerMoneyService extends CrudHttpClient<PacifistaPlayerMoneyDTO> {
+export class PlayerMoneyService extends CrudHttpClient<PlayerMoneyDTO> {
   constructor(protected httpClient: HttpClient, production: boolean) {
     super(
       httpClient,

--- a/projects/funixproductions-requests/src/public-api.ts
+++ b/projects/funixproductions-requests/src/public-api.ts
@@ -91,6 +91,10 @@ export * from './lib/services/pacifista-api/server/players/data/service/Pacifist
 export * from './lib/services/pacifista-api/server/players/data/service/PacifistaPlayerSessionsService';
 export * from './lib/services/pacifista-api/server/players/data/service/PacifistaPlayerChatMessagesService';
 
+export * from './lib/services/pacifista-api/server/players/sync/service/PlayerMoneyService';
+export * from './lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO';
+export * from './lib/services/pacifista-api/server/players/sync/dtos/PlayerMoneyDTO';
+
 export * from './lib/services/pacifista-api/web/user/dtos/PacifistaWebUserLinkDTO';
 export * from './lib/services/pacifista-api/web/user/services/PacifistaWebUserLinkService';
 


### PR DESCRIPTION
Issue:
- Forgot to add created files to public api layer
Changes:
- Renamed files according to api (e.g. `PacifistaPlayerMoneyDTO` -> `PlayerMoneyDTO`) as two files have the same name
- Added missing files to public api layer
- Update to `v0.4.3`