### PR TITLE
v0.4.4: Fix relative imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funixproductions/angular-core",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@angular/animations": "^19.1.7",
         "@angular/common": "^19.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Package used in all FunixProductions Angular projects",
   "scripts": {
     "ng": "ng",

--- a/projects/funixproductions-requests/package.json
+++ b/projects/funixproductions-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/funixproductions-requests",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Package used in all FunixProductions Angular projects",
   "peerDependencies": {
     "@angular/common": "^19.1.7",

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
@@ -1,4 +1,4 @@
-import {ApiDTO} from 'projects/funixproductions-requests/src/public-api';
+import {ApiDTO} from '../../../../../core/dtos/api-dto';
 
 export class PlayerDataDTO extends ApiDTO {
     public minecraftUuid: string;

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/service/PlayerMoneyService.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/service/PlayerMoneyService.ts
@@ -1,8 +1,8 @@
 import {HttpClient} from "@angular/common/http";
-import {CrudHttpClient} from "projects/funixproductions-requests/src/public-api";
+import {CrudHttpClient} from "../../../../../core/components/requests/crud-http-client";
 import {PlayerMoneyDTO} from "../dtos/PlayerMoneyDTO";
-import {environment} from "projects/funixproductions-requests/src/environments/environment";
-import {environmentDev} from "projects/funixproductions-requests/src/environments/environment-dev";
+import {environment} from "../../../../../../../environments/environment";
+import {environmentDev} from "../../../../../../../environments/environment-dev";
 
 export class PlayerMoneyService extends CrudHttpClient<PlayerMoneyDTO> {
   constructor(protected httpClient: HttpClient, production: boolean) {


### PR DESCRIPTION
# Issue:
- Imports were not relative, causing unknown paths
# Fix:
- Change import paths to use `../` instead of `project/`
# Notes:
- Pour le PacifistaWebsite, ces DTO (copiés de l'API) comprennent l'UUID mais pas le pseudo. Si jamais ca dérange, autant laisser ca en draft, update l'API puis update cette PR pour pouvoir merge proprement (et pas refaire encore une autre version xD)