### PR TITLE
v0.5.5: Fix incorrect var name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@funixproductions/angular-core",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@angular/animations": "^19.1.7",
         "@angular/common": "^19.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/angular-core",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Package used in all FunixProductions Angular projects",
   "scripts": {
     "ng": "ng",

--- a/projects/funixproductions-requests/package.json
+++ b/projects/funixproductions-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funixproductions/funixproductions-requests",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Package used in all FunixProductions Angular projects",
   "peerDependencies": {
     "@angular/common": "^19.1.7",

--- a/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
+++ b/projects/funixproductions-requests/src/lib/services/pacifista-api/server/players/sync/dtos/PlayerDataDTO.ts
@@ -1,10 +1,10 @@
 import {ApiDTO} from '../../../../../core/dtos/api-dto';
 
 export class PlayerDataDTO extends ApiDTO {
-    public minecraftUuid: string;
+    public playerOwnerUuid: string;
 
-    constructor(minecraftUuid: string) {
+    constructor(playerOwnerUuid: string) {
         super();
-        this.minecraftUuid = minecraftUuid;
+        this.playerOwnerUuid = playerOwnerUuid;
     }
 }


### PR DESCRIPTION
Fixed `PlayerDataDTO` using `minecraftUuid` instead of `playerOwnerUuid`
